### PR TITLE
Added NaN check when adding a value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+.idea

--- a/ma.go
+++ b/ma.go
@@ -1,4 +1,5 @@
 package movingaverage
+import "math"
 
 // @author Robin Verlangen
 // Moving average implementation for Go
@@ -36,6 +37,10 @@ func (ma *MovingAverage) Avg() float64 {
 }
 
 func (ma *MovingAverage) Add(val float64) {
+	if math.IsNaN(val) {
+		panic("Value to add is NaN.")
+	}
+
 	// Put into values array
 	ma.values[ma.valPos] = val
 


### PR DESCRIPTION
Adding a NaN value to the window results in the moving average to be NaN until the value is removed again. This prevents adding NaN values to the window, so this doesn't occur anymore.
