### PR TITLE
feat: add reset()

### DIFF
--- a/ma.go
+++ b/ma.go
@@ -82,6 +82,11 @@ func (ma *MovingAverage) Add(values ...float64) {
 	}
 }
 
+func (ma *MovingAverage) Reset() {
+	ma.valPos = 0
+	ma.slotsFilled = false
+}
+
 func (ma *MovingAverage) SlotsFilled() bool {
 	return ma.slotsFilled
 }

--- a/ma_concurrent.go
+++ b/ma_concurrent.go
@@ -19,6 +19,12 @@ func (c *ConcurrentMovingAverage) Add(values ...float64) {
 	c.mux.Unlock()
 }
 
+func (c *ConcurrentMovingAverage) Reset() {
+	c.mux.Lock()
+	c.ma.Reset()
+	c.mux.Unlock()
+}
+
 func (c *ConcurrentMovingAverage) Avg() float64 {
 	c.mux.RLock()
 	defer c.mux.RUnlock()

--- a/ma_test.go
+++ b/ma_test.go
@@ -171,3 +171,41 @@ func TestConcurrent(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+func TestReset(t *testing.T) {
+	a := New(5)
+	a.Add(10, 20, 30, 40, 50)
+	if a.Count() != 5 {
+		t.Error("expected 5 values before reset, got", a.Count())
+	}
+	if a.Avg() < 29.999 || a.Avg() > 30.001 {
+		t.Error("unexpected average before reset, got", a.Avg())
+	}
+
+	a.Reset()
+
+	if a.Count() != 0 {
+		t.Error("expected 0 values after reset, got", a.Count())
+	}
+	if a.Avg() != 0 {
+		t.Error("expected average 0 after reset, got", a.Avg())
+	}
+	if len(a.Values()) != 0 {
+		t.Error("expected no values after reset, got", len(a.Values()))
+	}
+	if a.SlotsFilled() {
+		t.Error("expected slots not filled after reset")
+	}
+
+	a.Add(10, 20)
+
+	if a.Count() != 2 {
+		t.Error("expected 2 values after adding 2 values after reset, got", a.Count())
+	}
+	if a.Avg() < 14.999 || a.Avg() > 15.001 {
+		t.Error("unexpected average after adding 2 values after reset, got", a.Avg())
+	}
+	if a.SlotsFilled() {
+		t.Error("expected slots not filled after adding 2 values after reset")
+	}
+}


### PR DESCRIPTION
This pull request introduces a new `Reset` method to both the `MovingAverage` and `ConcurrentMovingAverage` classes and adds corresponding unit tests to ensure the functionality works as expected.

Key changes include:

* **New `Reset` Method:**
  * [`ma.go`](diffhunk://#diff-608662302e7e27cd830e6d9acacad67dfb66759e3faf0a6303e48238696e5f23R85-R89): Added a `Reset` method to the `MovingAverage` class to reset its internal state.
  * [`ma_concurrent.go`](diffhunk://#diff-aec89a8bedb075bea3fa4b8b1e0f0762c41154c010d478c32e39c50df8bb2e06R22-R27): Added a `Reset` method to the `ConcurrentMovingAverage` class, ensuring thread safety by locking and unlocking the mutex.
  
* **Unit Tests:**
  * [`ma_test.go`](diffhunk://#diff-014b987985b4056d7cb1388d6b43c9c6c65fdb1b8b2ad48b85ec0c06704908f2R174-R211): Added a new test function `TestReset` to verify the behavior of the `Reset` method, including checking the count, average, and values before and after resetting.